### PR TITLE
COMPASS-3859 Scroll bar needs more contrast

### DIFF
--- a/src/components/sidebar/sidebar.less
+++ b/src/components/sidebar/sidebar.less
@@ -94,16 +94,16 @@
   }
 
   *::-webkit-scrollbar-track {
-    background-color: rgba(0,0,0,.12);
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    background-color: none;
     &:hover {
-      background-color: rgba(0,0,0,.24);
+      background-color: rgba(0,0,0,.16);
     }
   }
+  
   *::-webkit-scrollbar-thumb {
-    background-color: @compass-sidebar-base-background-color;
-    border: 1px solid rgba(0,0,0,.24);
+    background-color: rgba(255,255,255,.25);
+    -webkit-border-radius: 10px;
+    border-radius: 10px;
   }
 
   /* Styles for the big create database button at the bottom */


### PR DESCRIPTION
Updated scrollbar styles in sidebar for better accessibility. 
- Replaced white `scrollbar-thumb` with gray `scrollbar-thumb` (for light backgrounds)
- Replaced gray `scrollbar-thumb` with white `scrollbar-thumb` (for dark backgrounds)
- Removed background

<img width="709" alt="Screen Shot 2019-09-16 at 9 31 21 AM" src="https://user-images.githubusercontent.com/7270285/64972301-0e0dbd00-d877-11e9-9c21-7e1f900ef936.png">
