### PR TITLE
COMPASS-4353 - Handle non-view readonly collections in getSourceName

### DIFF
--- a/src/modules/collection.js
+++ b/src/modules/collection.js
@@ -17,14 +17,14 @@ export const getSource = (name, collections) => {
 /**
  * Generate a source namespace.
  *
- * @param {Boolean} isReadonly - If the collection is a view.
+ * @param {Boolean} isReadonly - If the collection is readonly, i.e. could be a view.
  * @param {String} database - The database name.
  * @param {String} name - The source collection name.
  *
  * @returns {String} The full source namespace.
  */
 export const getSourceName = (isReadonly, database, name) => {
-  if (isReadonly) {
+  if (isReadonly && name) {
     return `${database}.${name}`;
   }
   return null;

--- a/src/modules/collection.spec.js
+++ b/src/modules/collection.spec.js
@@ -53,6 +53,12 @@ describe('collection module', () => {
         expect(getSourceName(COLL.readonly)).to.equal(null);
       });
     });
+
+    context('when the collection is readonly but not a view', () => {
+      it('returns null', () => {
+        expect(getSourceName(true, 'db', undefined)).to.equal(null);
+      });
+    });
   });
 
   describe('#getSourceViewOn', () => {


### PR DESCRIPTION
Part of COMPASS-4353: `getSourceName()` used to think that “readonly” implies “is view”, making it sometimes return values like “databaseName.undefined”.

<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. COMPASS-1111: updates ace editor width in agg pipeline view -->

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->

### Checklist
- [x] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
