### PR TITLE
fix: Remove broken actions from dropdown and update icon COMPASS-4500

### DIFF
--- a/src/components/sidebar-collection/sidebar-collection.jsx
+++ b/src/components/sidebar-collection/sidebar-collection.jsx
@@ -39,22 +39,6 @@ class SidebarCollection extends PureComponent {
   }
 
   /**
-   * Import data to a collection dialog.
-   */
-  onImportData = () => {
-    const collectionName = this.getCollectionName();
-    this.props.globalAppRegistryEmit('open-import', collectionName);
-  }
-
-  /**
-   * Export data to a collection dialog.
-   */
-  onExportCollection = () => {
-    const collectionName = this.getCollectionName();
-    this.props.globalAppRegistryEmit('open-export', collectionName);
-  }
-
-  /**
    * Handle duplicate view.
    */
   onDuplicateView = () => {
@@ -176,7 +160,7 @@ class SidebarCollection extends PureComponent {
       <DropdownButton
         bsSize="xsmall"
         bsStyle="link"
-        title="&hellip;"
+        title={<i className="fa fa-fw fa-ellipsis-h" />}
         className={classnames(styles['compass-sidebar-item-collection-actions'])}
         noCaret
         pullRight
@@ -199,14 +183,12 @@ class SidebarCollection extends PureComponent {
       <DropdownButton
         bsSize="xsmall"
         bsStyle="link"
-        title="&hellip;"
+        title={<i className="fa fa-fw fa-ellipsis-h" />}
         className={classnames(styles['compass-sidebar-item-collection-actions'])}
         noCaret
         pullRight
         id="collection-actions">
         <MenuItem eventKey="1" onClick={this.onOpenInNewTab}>Open in New Tab</MenuItem>
-        <MenuItem eventKey="2" onClick={this.onImportData} disabled={this.isNotWritable()}>Import Data</MenuItem>
-        <MenuItem eventKey="2" onClick={this.onExportCollection}>Export Collection</MenuItem>
         <MenuItem eventKey="2" onClick={this.onDrop} disabled={this.isNotWritable()}>Drop Collection</MenuItem>
       </DropdownButton>
     );

--- a/src/components/sidebar-collection/sidebar-collection.less
+++ b/src/components/sidebar-collection/sidebar-collection.less
@@ -8,7 +8,6 @@
 @compass-sidebar-active-background-color: lighten(hsl(201, 11%, 41%), 10%);
 
 .compass-sidebar-item-collection-actions {
-  margin-right: 5px;
   color: @pw !important;
   visibility: hidden;
 }


### PR DESCRIPTION
## Description
This removes the two broken actions "Import Data" and "Export Data" from the dropdown of collections in the sidebar menu.
This PR also updates the dropdown button content to use the `fa-ellipsis-h` icon instead of `...` (textual ellipsis).

![image](https://user-images.githubusercontent.com/4354632/98946180-d7234d80-24f3-11eb-9759-281b877cc489.png)


### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added _(not needed since this dropdown is not documented)_

## Types of changes
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
