### PR TITLE
chore: update `data-service-initialized` to `data-service-connected` event COMPASS-4568

### DIFF
--- a/electron/renderer/index.js
+++ b/electron/renderer/index.js
@@ -6,7 +6,6 @@ import { AppContainer } from 'react-hot-loader';
 import SidebarPlugin, { activate } from 'plugin';
 import DeploymentStateStore from './stores/deployment-state-store';
 import { activate as appActivate } from '@mongodb-js/compass-app-stores';
-import { activate as headerActivate } from '@mongodb-js/compass-instance-header';
 import { activate as awarenessActivate } from '@mongodb-js/compass-deployment-awareness';
 import { activate as versionActivate } from '@mongodb-js/compass-server-version';
 import { activate as sshActivate } from '@mongodb-js/compass-ssh-tunnel-status';
@@ -26,7 +25,6 @@ global.hadronApp.instance = new InstanceModel();
 
 activate(appRegistry);
 appActivate(appRegistry);
-headerActivate(appRegistry);
 awarenessActivate(appRegistry);
 versionActivate(appRegistry);
 sshActivate(appRegistry);

--- a/electron/renderer/index.js
+++ b/electron/renderer/index.js
@@ -80,7 +80,6 @@ global.hadronApp.instance.genuineMongoDB = { isGenuine: false, dbType: 'cosmos' 
 const state = { instance: global.hadronApp.instance };
 
 DeploymentStateStore.setToInitial();
-appRegistry.emit('data-service-initialized', dataService);
 dataService.connect((error, ds) => {
   ds.client.model.sshTunnel = 'USER_PASSWORD';
   ds.client.model.sshTunnelHostname = '123.45.67.89';

--- a/package-lock.json
+++ b/package-lock.json
@@ -527,9 +527,9 @@
       }
     },
     "@mongodb-js/compass-deployment-awareness": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-deployment-awareness/-/compass-deployment-awareness-10.0.0.tgz",
-      "integrity": "sha512-DZsMTnukavWTsDVU6HJdLJbbA457xsRKeTYhtKtzg8Lt/wn8i84B9MQCYyfpPQYnuOaAn/Jk3dIvhUmJtDCsrA==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-deployment-awareness/-/compass-deployment-awareness-10.1.0.tgz",
+      "integrity": "sha512-dwKhYvpk79i/i98c0MYbHyGZvF9ijY3XfPYTnyVKWxIXrvXVsSMMRw0jTXEDEVbqweTOcZFHqXRhbowgf+h04g==",
       "dev": true
     },
     "@mongodb-js/compass-server-version": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -544,6 +544,12 @@
       "integrity": "sha512-flOtYugwjXzy1kkvjyFXp77qJE6GYlCvikUXTho/eZVHasEFv6Q46dK7mmj71+KKwVaaCAyqkvgw47ovMNDBvA==",
       "dev": true
     },
+    "@mongodb-js/triejs": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/triejs/-/triejs-0.1.5.tgz",
+      "integrity": "sha512-elh8S1OxmEGe8/wbr6ky//dHhV2ld6oZV8/M9lgozJsL/6Aqm8j5+ElquzoX9k9l3Q+dohuX/SIGR/kTRZHS4g==",
+      "dev": true
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
@@ -3290,13 +3296,13 @@
       "dev": true
     },
     "buffer": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
-      "integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
       "dev": true,
       "requires": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4"
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "buffer-alloc": {
@@ -11854,12 +11860,6 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
-    "long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
-      "dev": true
-    },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -13106,6 +13106,12 @@
         }
       }
     },
+    "mongodb-build-info": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/mongodb-build-info/-/mongodb-build-info-1.1.1.tgz",
+      "integrity": "sha512-HC4ZG98ObbWGM3ikL3VfSvuug3iQVpA2kBob/MxK+mn2PNdVTvR5lShio+Ev1rDqODfq3ePcfO6prfi0agQp8g==",
+      "dev": true
+    },
     "mongodb-collection-model": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/mongodb-collection-model/-/mongodb-collection-model-2.0.4.tgz",
@@ -13159,13 +13165,12 @@
       },
       "dependencies": {
         "bson": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/bson/-/bson-4.0.3.tgz",
-          "integrity": "sha512-7uBjjxwOSuGLmoqGI1UXWpDGc0K2WjR7dC6iaOg4iriNZo6M2EEBb8co4dEPJ5ArYCebPMie0ecgX0TWF+ZUrQ==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-4.2.2.tgz",
+          "integrity": "sha512-9fX257PVHAUpiRGmY3356RVWKQxLA73BgjA/x5MGuJkTEMeG7yzjuBrsiFB67EXRJnFVKrbJY9t/M+oElKYktQ==",
           "dev": true,
           "requires": {
-            "buffer": "^5.1.0",
-            "long": "^4.0.0"
+            "buffer": "^5.6.0"
           }
         }
       }
@@ -13189,40 +13194,250 @@
       }
     },
     "mongodb-data-service": {
-      "version": "16.5.5",
-      "resolved": "https://registry.npmjs.org/mongodb-data-service/-/mongodb-data-service-16.5.5.tgz",
-      "integrity": "sha512-Y3XgagtjFvSqdAMujqG3jrXzBQS7DKsXNd7XR4jJLbiJKOoP/cD12DgTan6VFy43d+DzP/KF8cTv20YBbUwa7w==",
+      "version": "18.2.1",
+      "resolved": "https://registry.npmjs.org/mongodb-data-service/-/mongodb-data-service-18.2.1.tgz",
+      "integrity": "sha512-s/3GydXC0VmdI1z2fQp3EqsPfkcMnc45q5c2VJowDOQpjXRF4i24QPtU01P97v+IN7pvge8O2ZNSFP2GoDzIMA==",
       "dev": true,
       "requires": {
-        "async": "^3.1.0",
-        "debug": "^4.1.1",
-        "lodash": "^4.17.0",
-        "mongodb": "^3.5.2",
-        "mongodb-collection-sample": "^4.4.4",
-        "mongodb-connection-model": "^14.6.2",
-        "mongodb-index-model": "^2.5.0",
+        "async": "^3.2.0",
+        "debug": "^4.2.0",
+        "lodash": "^4.17.20",
+        "mongodb-build-info": "^1.1.1",
+        "mongodb-collection-sample": "^4.5.1",
+        "mongodb-index-model": "^2.6.1",
         "mongodb-js-errors": "^0.5.0",
-        "mongodb-ns": "^2.0.0",
+        "mongodb-ns": "^2.2.0",
         "mongodb-security": "^0.2.0",
         "mongodb-url": "^3.0.3"
       },
       "dependencies": {
-        "mongodb-connection-model": {
-          "version": "14.6.2",
-          "resolved": "https://registry.npmjs.org/mongodb-connection-model/-/mongodb-connection-model-14.6.2.tgz",
-          "integrity": "sha512-Xa0jLNT+1j4n4NTxNiGQ+3fOQrrSuX37Bme9xFvnZe12XADS9770eb4BMOrT/FgnPY3OSzDt3CyWDyrMPcZsuA==",
+        "ampersand-class-extend": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/ampersand-class-extend/-/ampersand-class-extend-1.0.2.tgz",
+          "integrity": "sha1-jjqxJdCb976UO1DpjM5G/1F8vpE=",
           "dev": true,
           "requires": {
-            "ampersand-model": "^8.0.0",
+            "lodash.assign": "^3.0.0"
+          }
+        },
+        "ampersand-collection": {
+          "version": "1.6.1",
+          "resolved": "https://registry.npmjs.org/ampersand-collection/-/ampersand-collection-1.6.1.tgz",
+          "integrity": "sha1-Qw9lTPcC4Z0drGzSEXVdUDFyoMk=",
+          "dev": true,
+          "requires": {
+            "ampersand-class-extend": "^1.0.0",
+            "ampersand-events": "^1.0.1",
+            "ampersand-version": "^1.0.2",
+            "lodash.assign": "^3.0.0",
+            "lodash.bind": "^3.1.0",
+            "lodash.isarray": "^3.0.1"
+          }
+        },
+        "ampersand-events": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/ampersand-events/-/ampersand-events-1.1.1.tgz",
+          "integrity": "sha1-pQDpjMrorZKqHZV0TFM9nBChZTA=",
+          "dev": true,
+          "requires": {
+            "ampersand-version": "^1.0.2",
+            "lodash.assign": "^3.0.0",
+            "lodash.bind": "^3.1.0",
+            "lodash.foreach": "^3.0.2",
+            "lodash.isempty": "^3.0.1",
+            "lodash.keys": "^3.0.5",
+            "lodash.once": "^3.0.0",
+            "lodash.uniqueid": "^3.0.0"
+          }
+        },
+        "ampersand-model": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/ampersand-model/-/ampersand-model-6.0.3.tgz",
+          "integrity": "sha1-x+zlpnFVFT4TxyR1rPF4szhKVXw=",
+          "dev": true,
+          "requires": {
+            "ampersand-state": "^4.6.0",
+            "ampersand-sync": "^4.0.3",
+            "ampersand-version": "^1.0.2",
+            "lodash.assign": "^3.2.0",
+            "lodash.clone": "^3.0.3",
+            "lodash.isobject": "^3.0.2",
+            "lodash.result": "^3.1.2"
+          }
+        },
+        "ampersand-state": {
+          "version": "4.8.2",
+          "resolved": "https://registry.npmjs.org/ampersand-state/-/ampersand-state-4.8.2.tgz",
+          "integrity": "sha1-qPrjZakZ54S8icbqk6PzXvcvLDk=",
+          "dev": true,
+          "requires": {
+            "ampersand-events": "^1.1.1",
+            "ampersand-version": "^1.0.0",
+            "array-next": "~0.0.1",
+            "key-tree-store": "^1.3.0",
+            "lodash.assign": "^3.2.0",
+            "lodash.bind": "^3.1.0",
+            "lodash.escape": "^3.0.0",
+            "lodash.forown": "^3.0.2",
+            "lodash.has": "^3.0.0",
+            "lodash.includes": "^3.1.3",
+            "lodash.isarray": "^3.0.4",
+            "lodash.isdate": "^3.0.1",
+            "lodash.isequal": "^3.0.1",
+            "lodash.isfunction": "^3.0.6",
+            "lodash.isobject": "^3.0.1",
+            "lodash.isstring": "^3.0.1",
+            "lodash.omit": "^3.1.0",
+            "lodash.result": "^3.0.0",
+            "lodash.union": "^3.1.0",
+            "lodash.uniqueid": "^3.0.0"
+          }
+        },
+        "ampersand-sync": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/ampersand-sync/-/ampersand-sync-4.0.3.tgz",
+          "integrity": "sha1-wlXWBYhZUxRyEJ+KULocCtnY1yU=",
+          "dev": true,
+          "requires": {
+            "ampersand-version": "^1.0.0",
+            "lodash.assign": "^3.0.0",
+            "lodash.defaults": "^3.1.0",
+            "lodash.includes": "^3.1.0",
+            "lodash.result": "^3.0.0",
+            "media-type": "0.3.0",
+            "qs": "^4.0.0",
+            "request": "^2.55.0",
+            "xhr": "^2.0.5"
+          }
+        },
+        "async": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
+          "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
+          "dev": true
+        },
+        "bl": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
+          "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "^2.3.5",
+            "safe-buffer": "^5.1.1"
+          }
+        },
+        "bson": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.5.tgz",
+          "integrity": "sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg==",
+          "dev": true
+        },
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
+        },
+        "lodash.defaults": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-3.1.2.tgz",
+          "integrity": "sha1-xzCLGNv4vJNy1wGnNJPGEZK9Liw=",
+          "dev": true,
+          "requires": {
+            "lodash.assign": "^3.0.0",
+            "lodash.restparam": "^3.0.0"
+          }
+        },
+        "mongodb": {
+          "version": "3.6.3",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.3.tgz",
+          "integrity": "sha512-rOZuR0QkodZiM+UbQE5kDsJykBqWi0CL4Ec2i1nrGrUI3KO11r6Fbxskqmq3JK2NH7aW4dcccBuUujAP0ERl5w==",
+          "dev": true,
+          "requires": {
+            "bl": "^2.2.1",
+            "bson": "^1.1.4",
+            "denque": "^1.4.1",
+            "require_optional": "^1.0.1",
+            "safe-buffer": "^5.1.2",
+            "saslprep": "^1.0.0"
+          }
+        },
+        "mongodb-index-model": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/mongodb-index-model/-/mongodb-index-model-2.6.1.tgz",
+          "integrity": "sha512-F6CktBkd0U2uV1y8r6PhZQiKqAUND0HmZvlFMRqXnhPqGSI+SbiTaKxcwPUbXPzikGBSL8KaAujFGf/y41N0Tw==",
+          "dev": true,
+          "requires": {
+            "@mongodb-js/triejs": "^0.1.5",
+            "ampersand-collection": "^1.6.1",
+            "ampersand-model": "^6.0.2",
             "ampersand-rest-collection": "^6.0.0",
-            "async": "^3.1.0",
-            "debug": "^4.1.1",
-            "kerberos": "^1.1.3",
+            "async": "^3.2.0",
             "lodash": "^4.17.15",
-            "mongodb": "^3.5.2",
-            "raf": "^3.4.1",
-            "ssh2": "^0.8.7",
-            "storage-mixin": "^3.2.7"
+            "mongodb": "^3.5.4",
+            "mongodb-js-errors": "^0.5.0",
+            "mongodb-ns": "^2.2.0"
+          }
+        },
+        "qs": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz",
+          "integrity": "sha1-wx2bdOwn33XlQ6hseHKO2NRiNgc=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+              "dev": true
+            }
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+              "dev": true
+            }
           }
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -532,12 +532,6 @@
       "integrity": "sha512-DZsMTnukavWTsDVU6HJdLJbbA457xsRKeTYhtKtzg8Lt/wn8i84B9MQCYyfpPQYnuOaAn/Jk3dIvhUmJtDCsrA==",
       "dev": true
     },
-    "@mongodb-js/compass-instance-header": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-instance-header/-/compass-instance-header-0.2.4.tgz",
-      "integrity": "sha512-5SJXY1BUYP8s+SgKa96hT98oHA1Nz2TtyENaXeqpRlsk9VxKrCLCUxcdbt4kGI37e/Bx233jfXAgMQZEoNY3Og==",
-      "dev": true
-    },
     "@mongodb-js/compass-server-version": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@mongodb-js/compass-server-version/-/compass-server-version-4.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "mocha-webpack": "^2.0.0-beta.0",
     "moment": "^2.24.0",
     "mongodb-connection-model": "^14.5.1",
-    "mongodb-data-service": "^16.5.2",
+    "mongodb-data-service": "^18.2.1",
     "mongodb-database-model": "^0.1.3",
     "mongodb-instance-model": "^10.0.0",
     "mongodb-js-precommit": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "@mongodb-js/compass-app-stores": "^4.0.2",
     "@mongodb-js/compass-connect": "^5.3.3",
     "@mongodb-js/compass-deployment-awareness": "^10.0.0",
-    "@mongodb-js/compass-instance-header": "^0.2.2",
     "@mongodb-js/compass-server-version": "^4.0.0",
     "@mongodb-js/compass-ssh-tunnel-status": "^5.0.0",
     "autoprefixer": "^9.4.6",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@hot-loader/react-dom": "^16.9.0",
     "@mongodb-js/compass-app-stores": "^4.0.2",
     "@mongodb-js/compass-connect": "^5.3.3",
-    "@mongodb-js/compass-deployment-awareness": "^10.0.0",
+    "@mongodb-js/compass-deployment-awareness": "^10.1.0",
     "@mongodb-js/compass-server-version": "^4.0.0",
     "@mongodb-js/compass-ssh-tunnel-status": "^5.0.0",
     "autoprefixer": "^9.4.6",

--- a/src/stores/store.js
+++ b/src/stores/store.js
@@ -20,7 +20,7 @@ store.onActivated = (appRegistry) => {
   store.dispatch(globalAppRegistryActivated(appRegistry));
   store.dispatch(loadDetailsPlugins(appRegistry));
 
-  appRegistry.on('data-service-initialized', (dataService) => {
+  appRegistry.on('data-service-connected', (_, dataService) => {
     store.dispatch(changeConnection(dataService.client.model));
   });
 


### PR DESCRIPTION
Previously we were setting the data service with the `data-service-initialized` event. This event would sometimes pass a connection which does not successfully connect, and keeping it around will cause unexpected errors. This PR makes it so that we now listen for the `data-service-connected` to set the data service to avoid using an unreliable connection.

Compass connect pr which depends on this:
https://github.com/mongodb-js/compass-connect/pull/252