### PR TITLE
fix: editing favorite connectionModel prop misnaming

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -206,6 +206,40 @@
         "@babel/types": "^7.8.3"
       }
     },
+    "@babel/helper-module-imports": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.13.tgz",
+      "integrity": "sha512-NGmfvRp9Rqxy0uHSSVP+SRIW1q31a7Ji10cLBcqSDUngGentY4FRiHOFZFE1CLU5eiL0oE8reH7Tg1y99TDM/g==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.12.13"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.13.tgz",
+          "integrity": "sha512-oKrdZTld2im1z8bDwTOQvUbxKwE+854zc16qWZQlcTqMN00pWxHQ4ZeOq0yDMnisOpRykH2/5Qqcrk/OlbAjiQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.12.11",
+            "lodash": "^4.17.19",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
+        },
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+          "dev": true
+        }
+      }
+    },
     "@babel/helper-split-export-declaration": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
@@ -214,6 +248,12 @@
       "requires": {
         "@babel/types": "^7.8.3"
       }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+      "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+      "dev": true
     },
     "@babel/helpers": {
       "version": "7.8.4",
@@ -473,6 +513,73 @@
         "sumchecker": "^3.0.1"
       }
     },
+    "@emotion/cache": {
+      "version": "10.0.29",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz",
+      "integrity": "sha512-fU2VtSVlHiF27empSbxi1O2JFdNWZO+2NFHfwO0pxgTep6Xa3uGb+3pVKfLww2l/IBGLNEZl5Xf/++A4wAYDYQ==",
+      "dev": true,
+      "requires": {
+        "@emotion/sheet": "0.9.4",
+        "@emotion/stylis": "0.8.5",
+        "@emotion/utils": "0.11.3",
+        "@emotion/weak-memoize": "0.2.5"
+      }
+    },
+    "@emotion/hash": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
+      "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==",
+      "dev": true
+    },
+    "@emotion/memoize": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
+      "dev": true
+    },
+    "@emotion/serialize": {
+      "version": "0.11.16",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.16.tgz",
+      "integrity": "sha512-G3J4o8by0VRrO+PFeSc3js2myYNOXVJ3Ya+RGVxnshRYgsvErfAOglKAiy1Eo1vhzxqtUvjCyS5gtewzkmvSSg==",
+      "dev": true,
+      "requires": {
+        "@emotion/hash": "0.8.0",
+        "@emotion/memoize": "0.7.4",
+        "@emotion/unitless": "0.7.5",
+        "@emotion/utils": "0.11.3",
+        "csstype": "^2.5.7"
+      }
+    },
+    "@emotion/sheet": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.4.tgz",
+      "integrity": "sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA==",
+      "dev": true
+    },
+    "@emotion/stylis": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
+      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==",
+      "dev": true
+    },
+    "@emotion/unitless": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
+      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==",
+      "dev": true
+    },
+    "@emotion/utils": {
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
+      "integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw==",
+      "dev": true
+    },
+    "@emotion/weak-memoize": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
+      "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==",
+      "dev": true
+    },
     "@hot-loader/react-dom": {
       "version": "16.11.0",
       "resolved": "https://registry.npmjs.org/@hot-loader/react-dom/-/react-dom-16.11.0.tgz",
@@ -511,6 +618,144 @@
       "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
       "dev": true
     },
+    "@leafygreen-ui/box": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/box/-/box-3.0.2.tgz",
+      "integrity": "sha512-cyIw5POyivusUlHIVC3Enb5AVAAaLBF4DhdxPw9ymZL4lIJMZiRrFq7ayKykdyUXaB5jOnn+4qha2OXrgTYmJQ==",
+      "dev": true,
+      "requires": {
+        "@leafygreen-ui/lib": "^6.0.1",
+        "lodash": "^4.17.20"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
+        }
+      }
+    },
+    "@leafygreen-ui/button": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/button/-/button-10.0.1.tgz",
+      "integrity": "sha512-Lt1/3juStJAJsaOKptf89KoNwuuGKqKDFTJ71OQ5dsZvg6cnIVFpeb9trckfknc3xGZ3P0Jfj3T5R/V6n1jRtA==",
+      "dev": true,
+      "requires": {
+        "@leafygreen-ui/box": "^3.0.1",
+        "@leafygreen-ui/interaction-ring": "^1.0.0",
+        "@leafygreen-ui/lib": "^6.1.2",
+        "@leafygreen-ui/palette": "^3.1.0",
+        "lodash": "^4.17.20"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
+        }
+      }
+    },
+    "@leafygreen-ui/emotion": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/emotion/-/emotion-3.0.1.tgz",
+      "integrity": "sha512-h0VaYrbwC7jNpGKXq81qu4QveT9lyPQFDRrcePIL+UoDA8nLRzs+5T2oxyJkHqulmgHrRTmLEXv2pIuJinbKHA==",
+      "dev": true,
+      "requires": {
+        "create-emotion": "^10.0.7",
+        "create-emotion-server": "10.0.27",
+        "emotion": "^10.0.7"
+      }
+    },
+    "@leafygreen-ui/hooks": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/hooks/-/hooks-6.0.0.tgz",
+      "integrity": "sha512-KkOOhiQ+kgiaJo0Uj5kxyYKHillJUzbofy6qFPwjvsf2jZ1LbEsd/1RB9Ck5UDbaiRMhmdSBkWux4u8fOy42BA==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.20"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
+        }
+      }
+    },
+    "@leafygreen-ui/icon": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-9.0.0.tgz",
+      "integrity": "sha512-CoFB1Cuunu5uvGiy3FSLKr2Na2suzyZ3uNYuAGXHmqlTOfD62eYODedwmOWeFTTCYJE9AWLZ3BFTxL8rn4OFOA==",
+      "dev": true,
+      "requires": {
+        "@leafygreen-ui/lib": "^6.1.2"
+      }
+    },
+    "@leafygreen-ui/interaction-ring": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/interaction-ring/-/interaction-ring-1.0.1.tgz",
+      "integrity": "sha512-Q7Vj07vkAtZdA99PWv80Z9mswseDIZBTYTwEfjfeKkUyE04+YLrafAhOR7lZGjgaO/1HUBhx07mPUxAcUWqs9Q==",
+      "dev": true,
+      "requires": {
+        "@leafygreen-ui/emotion": "^3.0.1",
+        "@leafygreen-ui/leafygreen-provider": "^2.0.1",
+        "@leafygreen-ui/lib": "^6.1.2",
+        "@leafygreen-ui/palette": "^3.1.0"
+      }
+    },
+    "@leafygreen-ui/leafygreen-provider": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/leafygreen-provider/-/leafygreen-provider-2.0.2.tgz",
+      "integrity": "sha512-0lGFRJWuhao4OcPtMYhA+tH8VceCdz8HCL7oDylJTCDhw4NbFATsyy4abeJc+WKFngzR6EwlOaLeC5HFsJMu9A==",
+      "dev": true,
+      "requires": {
+        "@leafygreen-ui/hooks": "^6.0.0",
+        "@leafygreen-ui/lib": "^6.1.1"
+      }
+    },
+    "@leafygreen-ui/lib": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-6.2.0.tgz",
+      "integrity": "sha512-gC2XzBYmx5vHCXbmZag1jq5OwrY3KGG1Ihl/5xEHp2t9u85cWywcL2ZOhkhx8jirCoRYyO+bXgzuhupByqUw6w==",
+      "dev": true,
+      "requires": {
+        "@leafygreen-ui/emotion": "^3.0.1",
+        "facepaint": "^1.2.1",
+        "polished": "^2.3.0",
+        "prop-types": "^15.0.0"
+      }
+    },
+    "@leafygreen-ui/palette": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-3.1.0.tgz",
+      "integrity": "sha512-+KuBtiSD72vwWb2VMoDX1AJ6eLjsbWcQcJgmkNxWNih4DtJieufNxTxsJwvPRWoe6ik1yfchBJnugehLEAvHIQ==",
+      "dev": true
+    },
+    "@leafygreen-ui/tokens": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-0.5.0.tgz",
+      "integrity": "sha512-1rnFI1NSNtddMtRzwy4rS/4NF3rO7eK1dbw/+h+VAqY1OZHNJinV0R283QJajx2dMttm20mOpTN6v099kM0SxQ==",
+      "dev": true,
+      "requires": {
+        "@leafygreen-ui/lib": "^6.0.1"
+      }
+    },
+    "@leafygreen-ui/typography": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@leafygreen-ui/typography/-/typography-7.3.2.tgz",
+      "integrity": "sha512-MsgsJFfP/VvngsR0VxcZGGF1j6IKiUKsHGN0PQWSox3u5+CIQh3ZtkiG3C3CziNbuJcqCw1ieMOxCHkRb07zNA==",
+      "dev": true,
+      "requires": {
+        "@leafygreen-ui/box": "^3.0.2",
+        "@leafygreen-ui/icon": "^9.0.0",
+        "@leafygreen-ui/lib": "^6.1.2",
+        "@leafygreen-ui/palette": "^3.1.0",
+        "@leafygreen-ui/tokens": "^0.5.0"
+      }
+    },
     "@mongodb-js/compass-app-stores": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@mongodb-js/compass-app-stores/-/compass-app-stores-4.0.2.tgz",
@@ -518,12 +763,15 @@
       "dev": true
     },
     "@mongodb-js/compass-connect": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-connect/-/compass-connect-5.4.5.tgz",
-      "integrity": "sha512-rwcnNgoaCZdl/yiCs6VOXNVxamjHTb4HfLfBGKJIN98rp4bmVVhOIVg6uvAbI1Hl0G/muRdfotOGHHY783/40g==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/compass-connect/-/compass-connect-6.1.2.tgz",
+      "integrity": "sha512-MFYzLvcqrSXtLbjlOCowsjKGsPAOdO4+8u/SMo/jUNFq98g8rPHNE8UhjHuDljjIYePHT8aK0g3U7X2DfxHAgg==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.15"
+        "@leafygreen-ui/button": "^10.0.1",
+        "@leafygreen-ui/typography": "^7.3.2",
+        "lodash": "^4.17.15",
+        "react-ios-switch": "^0.1.19"
       }
     },
     "@mongodb-js/compass-deployment-awareness": {
@@ -670,6 +918,12 @@
       "version": "10.17.14",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.14.tgz",
       "integrity": "sha512-G0UmX5uKEmW+ZAhmZ6PLTQ5eu/VPaT+d/tdLd5IFsKRPcbe6lPxocBtcYBFSaLaCW8O60AX90e91Nsp8lVHCNw==",
+      "dev": true
+    },
+    "@types/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
     },
     "@types/prop-types": {
@@ -2075,6 +2329,92 @@
       "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-emotion": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.2.2.tgz",
+      "integrity": "sha512-SMSkGoqTbTyUTDeuVuPIWifPdUGkTk1Kf9BWRiXIOIcuyMfsdp2EjeiiFvOzX8NOBvEh/ypKYvUh2rkgAJMCLA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@emotion/hash": "0.8.0",
+        "@emotion/memoize": "0.7.4",
+        "@emotion/serialize": "^0.11.16",
+        "babel-plugin-macros": "^2.0.0",
+        "babel-plugin-syntax-jsx": "^6.18.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^1.0.5",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7"
+      },
+      "dependencies": {
+        "find-root": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+          "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "babel-plugin-macros": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
+      "integrity": "sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.7.2",
+        "cosmiconfig": "^6.0.0",
+        "resolve": "^1.12.0"
+      },
+      "dependencies": {
+        "cosmiconfig": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
+          "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+          "dev": true,
+          "requires": {
+            "@types/parse-json": "^4.0.0",
+            "import-fresh": "^3.1.0",
+            "parse-json": "^5.0.0",
+            "path-type": "^4.0.0",
+            "yaml": "^1.7.2"
+          }
+        },
+        "import-fresh": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+          "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+          "dev": true,
+          "requires": {
+            "parent-module": "^1.0.0",
+            "resolve-from": "^4.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+          "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-even-better-errors": "^2.3.0",
+            "lines-and-columns": "^1.1.6"
+          }
+        },
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+          "dev": true
+        }
       }
     },
     "babel-plugin-syntax-class-properties": {
@@ -4283,6 +4623,30 @@
         "elliptic": "^6.0.0"
       }
     },
+    "create-emotion": {
+      "version": "10.0.27",
+      "resolved": "https://registry.npmjs.org/create-emotion/-/create-emotion-10.0.27.tgz",
+      "integrity": "sha512-fIK73w82HPPn/RsAij7+Zt8eCE8SptcJ3WoRMfxMtjteYxud8GDTKKld7MYwAX2TVhrw29uR1N/bVGxeStHILg==",
+      "dev": true,
+      "requires": {
+        "@emotion/cache": "^10.0.27",
+        "@emotion/serialize": "^0.11.15",
+        "@emotion/sheet": "0.9.4",
+        "@emotion/utils": "0.11.3"
+      }
+    },
+    "create-emotion-server": {
+      "version": "10.0.27",
+      "resolved": "https://registry.npmjs.org/create-emotion-server/-/create-emotion-server-10.0.27.tgz",
+      "integrity": "sha512-1EbZgdjiho9ue1BSTpAez8SIdfbTXomtz0bg+LPOEvf/5OV7xqCGJaoSCDCB+y7kZ73hwoEhLsoPmqKSGIQMXg==",
+      "dev": true,
+      "requires": {
+        "@emotion/utils": "0.11.3",
+        "html-tokenize": "^2.0.0",
+        "multipipe": "^1.0.2",
+        "through": "^2.3.8"
+      }
+    },
     "create-hash": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
@@ -5390,6 +5754,53 @@
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
       "dev": true
     },
+    "duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^2.0.2"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
     "duplexer3": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
@@ -5711,6 +6122,16 @@
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
       "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
       "dev": true
+    },
+    "emotion": {
+      "version": "10.0.27",
+      "resolved": "https://registry.npmjs.org/emotion/-/emotion-10.0.27.tgz",
+      "integrity": "sha512-2xdDzdWWzue8R8lu4G76uWX5WhyQuzATon9LmNeCy/2BHVC6dsEpfhN1a0qhELgtDVdjyEA6J8Y/VlI5ZnaH0g==",
+      "dev": true,
+      "requires": {
+        "babel-plugin-emotion": "^10.0.27",
+        "create-emotion": "^10.0.27"
+      }
     },
     "encodeurl": {
       "version": "1.0.2",
@@ -6712,6 +7133,12 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
+    },
+    "facepaint": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/facepaint/-/facepaint-1.2.1.tgz",
+      "integrity": "sha512-oNvBekbhsm/0PNSOWca5raHNAi6dG960Bx6LJgxDPNF59WpuspgQ17bN5MKwOr7JcFdQYc7StW3VZ28DBZLavQ==",
       "dev": true
     },
     "fast-deep-equal": {
@@ -8814,6 +9241,58 @@
         }
       }
     },
+    "html-tokenize": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/html-tokenize/-/html-tokenize-2.0.1.tgz",
+      "integrity": "sha512-QY6S+hZ0f5m1WT8WffYN+Hg+xm/w5I8XeUcAq/ZYP5wVC8xbKi4Whhru3FtrAebD5EhBW8rmFzkDI6eCAuFe2w==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "~0.1.1",
+        "inherits": "~2.0.1",
+        "minimist": "~1.2.5",
+        "readable-stream": "~1.0.27-1",
+        "through2": "~0.4.1"
+      },
+      "dependencies": {
+        "buffer-from": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.2.tgz",
+          "integrity": "sha512-RiWIenusJsmI2KcvqQABB83tLxCByE3upSP8QU3rJDMVFGPWLvPQJt/O1Su9moRWeH7d+Q2HYb68f6+v+tw2vg==",
+          "dev": true
+        },
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        },
+        "object-keys": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+          "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=",
+          "dev": true
+        },
+        "through2": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
+          "integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
+          "dev": true,
+          "requires": {
+            "readable-stream": "~1.0.17",
+            "xtend": "~2.1.1"
+          }
+        },
+        "xtend": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+          "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
+          "dev": true,
+          "requires": {
+            "object-keys": "~0.4.0"
+          }
+        }
+      }
+    },
     "html-webpack-plugin": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz",
@@ -10067,6 +10546,12 @@
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
     },
+    "json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true
+    },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
@@ -10737,6 +11222,12 @@
       "requires": {
         "immediate": "~3.0.5"
       }
+    },
+    "lines-and-columns": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+      "dev": true
     },
     "loader-runner": {
       "version": "2.4.0",
@@ -14174,6 +14665,16 @@
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
       "dev": true
     },
+    "multipipe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-1.0.2.tgz",
+      "integrity": "sha1-zBPv2DPJzamfIk+GhGG44aP9k50=",
+      "dev": true,
+      "requires": {
+        "duplexer2": "^0.1.2",
+        "object-assign": "^4.1.0"
+      }
+    },
     "mute-stream": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
@@ -15480,6 +15981,12 @@
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
       "dev": true
     },
+    "path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true
+    },
     "pathval": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
@@ -15657,6 +16164,15 @@
           "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "dev": true
         }
+      }
+    },
+    "polished": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/polished/-/polished-2.3.3.tgz",
+      "integrity": "sha512-59V4fDbdxtH4I1m9TWxFsoGJbC8nnOpUYo5uFmvMfKp9Qh+6suo4VMUle1TGIIUZIGxfkW+Rs485zPk0wcwR2Q==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.2.0"
       }
     },
     "popmotion": {
@@ -20368,6 +20884,12 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
+    },
+    "yaml": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
+      "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==",
       "dev": true
     },
     "yargs": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@hot-loader/react-dom": "^16.9.0",
     "@mongodb-js/compass-app-stores": "^4.0.2",
-    "@mongodb-js/compass-connect": "^5.3.3",
+    "@mongodb-js/compass-connect": "^6.1.2",
     "@mongodb-js/compass-deployment-awareness": "^10.1.0",
     "@mongodb-js/compass-server-version": "^4.0.0",
     "@mongodb-js/compass-ssh-tunnel-status": "^5.0.0",

--- a/src/components/sidebar-instance/sidebar-instance.jsx
+++ b/src/components/sidebar-instance/sidebar-instance.jsx
@@ -64,7 +64,7 @@ class SidebarInstance extends PureComponent {
     if (this.props.isModalVisible) {
       return (
         <FavoriteModal
-          currentConnection={this.props.connectionModel.connection}
+          connectionModel={this.props.connectionModel.connection}
           deleteFavorite={this.deleteFavorite.bind(this)}
           closeFavoriteModal={this.closeFavoriteModal.bind(this)}
           saveFavorite={this.saveFavorite.bind(this)} />


### PR DESCRIPTION
COMPASS-4636

We renamed `currentConnection` to `connectionModel` in compass-connect. Missed this use of it. Did a search in the rest of compass, couldn't find any more cases.

Now works:
<img width="507" alt="Screen Shot 2021-02-15 at 12 50 45 PM" src="https://user-images.githubusercontent.com/1791149/107943075-6c6b2d80-6f8c-11eb-98d5-60f8ebf4e5be.png">
